### PR TITLE
update chat history retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /__pycache__
 /env
 /utils/__pycache__
+.idea

--- a/OpenAI-Assistant-Template.ipynb
+++ b/OpenAI-Assistant-Template.ipynb
@@ -5,14 +5,16 @@
    "metadata": {},
    "source": [
     "# You can use this as a template to quickly create an Assistant using OpenAI's Assistant API"
-   ]
+   ],
+   "id": "483877a23d9d69de"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Import Packages"
-   ]
+   ],
+   "id": "e36951703b5abc19"
   },
   {
    "cell_type": "code",
@@ -25,7 +27,8 @@
     "from utils.modules import *\n",
     "load_dotenv() # Load .env file\n",
     "from openai import OpenAI\n",
-    "client = OpenAI() # Initialize OpenAI Client"
+    "client = OpenAI() # Initialize OpenAI Client\n",
+    "from IPython.display import display, Markdown"
    ]
   },
   {
@@ -41,7 +44,8 @@
     "-> For Threads -\n",
     "* Set ```get_previous_thread = False``` to create a new thread.\n",
     "* Set ```get_previous_thread = True``` if you want to use a previous thread.\n"
-   ]
+   ],
+   "id": "9eba395ec5bbb08e"
   },
   {
    "cell_type": "code",
@@ -54,14 +58,16 @@
     "\n",
     "assistant_id_to_use = \"asst_6waRJUR4EfaVRYWLkqetgSuu\"\n",
     "thread_id_to_use = \"thread_bBkIkcD7yZW3QtrIYt6GMj5e\""
-   ]
+   ],
+   "id": "adf9d65fd6effdbe"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Get Assistant using assistant id"
-   ]
+   ],
+   "id": "22c7e9588b374fe5"
   },
   {
    "cell_type": "code",
@@ -90,14 +96,16 @@
     "    ]\n",
     "    assistant = create_assistant(client, name, description, instructions) # Create Assistant\n",
     "    print(\"New Assistant created with ID: \" + assistant.id)"
-   ]
+   ],
+   "id": "7771e41f4fce875e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Retrieve the previous conversation"
-   ]
+   ],
+   "id": "b2cf658b7cb5eb8c"
   },
   {
    "cell_type": "code",
@@ -122,14 +130,16 @@
     "else:\n",
     "    thread = start_new_chat(client)\n",
     "    print(\"New chat created with ID: \" + thread.id)"
-   ]
+   ],
+   "id": "28b405d0bd043659"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Add new message into thread"
-   ]
+   ],
+   "id": "953a2c6c745145fd"
   },
   {
    "cell_type": "code",
@@ -140,7 +150,8 @@
     "# Message to send to the assistant\n",
     "\n",
     "content = \"What does the male need to do with the female to reproduce?\""
-   ]
+   ],
+   "id": "f5003687617b67d4"
   },
   {
    "cell_type": "code",
@@ -160,14 +171,16 @@
     "\n",
     "new_message = add_message(client, thread, content)\n",
     "print(new_message)"
-   ]
+   ],
+   "id": "8830540a71fcdc6f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Run the thread with the new message"
-   ]
+   ],
+   "id": "4ebf12c223c9d5c3"
   },
   {
    "cell_type": "code",
@@ -189,14 +202,16 @@
     "# Run the thread with the assistant with the new message\n",
     "\n",
     "run_chat(client, thread, assistant)"
-   ]
+   ],
+   "id": "832ad5ff2f179aa0"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Run the below code everytime you need to see the new chats"
-   ]
+   ],
+   "id": "82130b61634a30ad"
   },
   {
    "cell_type": "code",
@@ -226,10 +241,14 @@
     "# Retrieve the chat history\n",
     "\n",
     "history = get_messages_in_chat(client, thread)\n",
-    "messages = history.data[::-1]\n",
-    "for i in messages:\n",
-    "    print(i.role.upper() + \": \"+ i.content[0].text.value)"
-   ]
+    "\n",
+    "# Convert the SyncCursorPage object to a list and reverse the order for display\n",
+    "messages = list(history)[::-1]\n",
+    "\n",
+    "# Call the display function with the reversed messages\n",
+    "display_chat_messages(messages)\n"
+   ],
+   "id": "577f6266c05babee"
   }
  ],
  "metadata": {

--- a/utils/modules.py
+++ b/utils/modules.py
@@ -50,3 +50,17 @@ def run_chat(client, thread, assistant):
     assistant_id=assistant.id,
     )
     return run
+
+# Description: "Display the chat messages"
+def display_chat_messages(messages):
+    for message in messages:
+        role = message.role.upper()
+        content = message.content[0].text.value
+        formatted_message = f"{role}: {content}"
+
+        if role == "USER":
+            # Display user messages in markdown cells (add formatting if required)
+            display(Markdown(f"{formatted_message}"))
+        else:
+            # Display assistant messages in markdown cells (add formatting if required)
+            display(Markdown(f"{formatted_message}"))


### PR DESCRIPTION
# Pull Request: Complete Chat History Retrieval Fix

## Background
The initial implementation of the chat history retrieval functionality within the Jupyter notebook environment had a limitation that prevented it from displaying the full chat archive, particularly for extensive chat histories. It was observed that the chat messages were being truncated to a certain point, thereby not providing the complete historical record of conversations.

## Issue
Upon investigation, the underlying cause of the issue was identified as the method used to retrieve chat messages. The `get_messages_in_chat` function's result was being directly manipulated without handling the potential for non-list iterable types.

## Proposed Solution
This commit overhauls the chat history retrieval logic to ensure:
- All messages are fetched from the chat thread, including those from extensive archives.
- Proper reversal of messages for chronological display without causing `TypeError`.

## Code Changes
The specific changes made are as follows:

- [x] Modified the message retrieval logic to handle the `SyncCursorPage[ThreadMessage]` object type, which includes using the `list()` constructor to allow for subsequent list operations, such as reversing.
- [x] Implemented a consistent message reversal process, using slicing, to display messages in the correct chronological order, with the oldest message appearing first.

## Result
These changes result in the complete chat history being fetched and displayed correctly, resolving the issue of truncated messages. Both extensive and short chat histories are now fully retrievable and viewable in the expected order.